### PR TITLE
Make the `id` attribute not mandatory

### DIFF
--- a/CERIF-Model-Tools/src/main/resources/xsd/includes/cerif-commons.xsd
+++ b/CERIF-Model-Tools/src/main/resources/xsd/includes/cerif-commons.xsd
@@ -78,7 +78,7 @@
 
 	<xs:complexType name="cfIdAttr__BaseType">
 		<xs:sequence/>
-		<xs:attribute name="id" type="cfId__SimpleType"/>
+		<xs:attribute name="id" type="cfId__SimpleType" use="optional"/>
 		<xs:attributeGroup ref="cfExtension__AttributeGroup"/>
 	</xs:complexType>
 


### PR DESCRIPTION
For https://github.com/openaire/guidelines-cris-managers/issues/56